### PR TITLE
Improve internal column detection

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2007880'
+ValidationKey: '2027862'
 AutocreateReadme: no
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'GDPuc: Easily Convert GDP Data'
-version: 1.0.1
-date-released: '2024-06-06'
+version: 1.0.2
+date-released: '2024-06-07'
 abstract: Convert GDP time series data from one unit to another. All common GDP units
   are included, i.e. current and constant local currency units, US$ via market exchange
   rates and international dollars via purchasing power parities.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GDPuc
 Title: Easily Convert GDP Data
-Version: 1.0.1
-Date: 2024-06-06
+Version: 1.0.2
+Date: 2024-06-07
 Authors@R:
     person("Johannes", "Koch", , "jokoch@pik-potsdam.de", role = c("aut", "cre"))
 Description: Convert GDP time series data from one unit to

--- a/R/transform_user_input.R
+++ b/R/transform_user_input.R
@@ -4,7 +4,14 @@ transform_user_input <- function(gdp, unit_in, unit_out, source, use_USA_deflato
 
   # Convert to tibble, if necessary
   if (class(gdp)[1] == "magpie") {
-    gdp <- tibble::as_tibble(gdp) %>% dplyr::rename(tidyselect::any_of(c("iso3c" = "region")))
+    # Check if the magpie object has 2 spatial dimensions
+    spat2 <- all(grepl("\\.", magclass::getItems(gdp, dim = 1)))
+    gdp <- tibble::as_tibble(gdp)
+    if (!spat2) {
+      gdp <- gdp %>% dplyr::rename("iso3c" = 1, "year" = 2)
+    } else {
+      gdp <- gdp %>% dplyr::rename("iso3c" = 1, "spatial2" = 2, "year" = 3)
+    }
   }
 
   # Extract base years if they exist, and adjust string
@@ -118,7 +125,13 @@ transform_internal <- function(x, gdp, with_regions, require_year_column) {
 
   # Transform into original gdp type
   if (class(gdp)[1] == "magpie") {
-    x <- magclass::as.magpie(x, spatial = "iso3c", temporal = "year")
+    # Check if the original magpie object had 2 spatial dimensions
+    spat2 <- all(grepl("\\.", magclass::getItems(gdp, dim = 1)))
+    if (!spat2) {
+      x <- magclass::as.magpie(x, spatial = "iso3c", temporal = "year")
+    } else {
+      x <- magclass::as.magpie(x, spatial = c("iso3c", "spatial2"), temporal = "year")
+    }
     magclass::getSets(x) <- magclass::getSets(gdp)
     return(x)
   }

--- a/tests/testthat/test-05_convertGDP.R
+++ b/tests/testthat/test-05_convertGDP.R
@@ -68,12 +68,18 @@ test_that("convertGDP magpie object", {
                                  years = c(2001, 2002),
                                  names = c("ssp1", "ssp2"),
                                  fill = 100)
-  magclass::getSets(gdp_in)[1] <- c("iso3c")
+  gdp_in2 <- magclass::new.magpie("USA.FRA",
+                                  years = c(2001, 2002),
+                                  names = c("ssp1", "ssp2"),
+                                  fill = 100)
+  gdp_conv  <- convertGDP(gdp_in, "current LCU", "constant 2017 Int$PPP")
+  gdp_conv2 <- convertGDP(gdp_in2, "current LCU", "constant 2017 Int$PPP")
 
-  gdp_conv <- convertGDP(gdp_in, "current LCU", "constant 2017 Int$PPP")
 
   expect_s4_class(gdp_conv, "magpie")
-  expect_mapequal(magclass::getSets(gdp_in), magclass::getSets(gdp_conv))
+  expect_s4_class(gdp_conv2, "magpie")
+  expect_mapequal(magclass::getSets(gdp_in),  magclass::getSets(gdp_conv))
+  expect_mapequal(magclass::getSets(gdp_in2), magclass::getSets(gdp_conv2))
 })
 
 


### PR DESCRIPTION
For magpie objects, we can use the order of columns when determining which refer to the iso3c and year columns.
At the same time we need to check for an eventual second spatial dimension (fixes https://github.com/pik-piam/GDPuc/issues/22).