### PR TITLE
handle missing years in magclass object

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,8 +1,8 @@
-ValidationKey: '2027862'
+ValidationKey: '2072720'
 AutocreateReadme: no
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
-AcceptedNotes: ~
+AcceptedNotes: 'Namespace in Imports field not imported from: ‘crayon’'
 allowLinterWarnings: yes
 enforceVersionUpdate: no

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'GDPuc: Easily Convert GDP Data'
-version: 1.0.2
-date-released: '2024-06-07'
+version: 1.0.4
+date-released: '2024-07-26'
 abstract: Convert GDP time series data from one unit to another. All common GDP units
   are included, i.e. current and constant local currency units, US$ via market exchange
   rates and international dollars via purchasing power parities.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GDPuc
 Title: Easily Convert GDP Data
-Version: 1.0.2
-Date: 2024-06-07
+Version: 1.0.4
+Date: 2024-07-26
 Authors@R:
     person("Johannes", "Koch", , "jokoch@pik-potsdam.de", role = c("aut", "cre"))
 Description: Convert GDP time series data from one unit to
@@ -42,4 +42,4 @@ VignetteBuilder:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/check_user_input.R
+++ b/R/check_user_input.R
@@ -38,12 +38,6 @@ check_gdp <- function(gdp) {
   } else if (inherits(gdp, "magpie")) {
     # Check for magclass package
     rlang::check_installed("magclass", reason = "in order for magpie objects to be recognized.")
-    # Check if there is years info
-    if (is.null(magclass::getYears(gdp))) {
-      # I need at least one explizit call to a crayon:: function... otherwise I get a CRAN note
-      h <- crayon::bold("magpie")
-      abort("Invalid 'gdp' argument. No year information in {h} object.")
-    }
   } else {
     abort("Invalid 'gdp' argument. 'gdp' is neither a data-frame nor a 'magpie' object.")
   }

--- a/R/check_user_input.R
+++ b/R/check_user_input.R
@@ -12,7 +12,9 @@ check_user_input <- function(gdp,
                              verbose,
                              return_cfs) {
 
-  check_gdp(gdp)
+  require_year_column <- any(grepl("current", c(unit_in, unit_out)))
+
+  check_gdp(gdp, require_year_column)
   check_unit_in_out(unit_in, unit_out)
   source <- check_source(source)
   check_use_USA_deflator_for_all(use_USA_deflator_for_all, unit_in, unit_out)
@@ -27,7 +29,7 @@ check_user_input <- function(gdp,
 
 
 # Check 'gdp' input parameter
-check_gdp <- function(gdp) {
+check_gdp <- function(gdp, require_year_column) {
   if (is.data.frame(gdp)) {
     if (! "value" %in% colnames(gdp)) {
       abort("Invalid 'gdp' argument. 'gdp' does not have the required 'value' column.")
@@ -38,6 +40,12 @@ check_gdp <- function(gdp) {
   } else if (inherits(gdp, "magpie")) {
     # Check for magclass package
     rlang::check_installed("magclass", reason = "in order for magpie objects to be recognized.")
+
+    # Check if there is years info
+    if (is.null(magclass::getYears(gdp)) && require_year_column) {
+      abort("Invalid 'gdp' argument. No year information in {crayon::bold('magpie')} object.")
+    }
+
   } else {
     abort("Invalid 'gdp' argument. 'gdp' is neither a data-frame nor a 'magpie' object.")
   }

--- a/R/convertGDP.R
+++ b/R/convertGDP.R
@@ -76,7 +76,7 @@
 #'     \item "regional_average": missing conversion factors in the source object are replaced with
 #'     the regional average of the region to which the country belongs. This requires a region-mapping to
 #'     be passed to the function, see the with_regions argument.
-#'     \item "with USA": missing conversion factors in the source object are replaced with
+#'     \item "with_USA": missing conversion factors in the source object are replaced with
 #'     the conversion factors of the USA.
 #'   }
 #'   Can also be a vector with "linear" as first element, e.g. c("linear", 0) or c("linear", "no_conversion"),

--- a/R/transform_user_input.R
+++ b/R/transform_user_input.R
@@ -7,7 +7,7 @@ transform_user_input <- function(gdp, unit_in, unit_out, source, use_USA_deflato
 
     tb <- tibble::as_tibble(gdp)
 
-    if (is.null(getItems(gdp, dim = 2))){
+    if (is.null(magclass::getItems(gdp, dim = 2))) {
       tb <- tb %>% tibble::add_column(year = 0, .after = 1)
     }
 

--- a/man/convertGDP.Rd
+++ b/man/convertGDP.Rd
@@ -83,7 +83,7 @@ For the extrapolation, the closest 5 data points are used.
 \item "regional_average": missing conversion factors in the source object are replaced with
 the regional average of the region to which the country belongs. This requires a region-mapping to
 be passed to the function, see the with_regions argument.
-\item "with USA": missing conversion factors in the source object are replaced with
+\item "with_USA": missing conversion factors in the source object are replaced with
 the conversion factors of the USA.
 }
 Can also be a vector with "linear" as first element, e.g. c("linear", 0) or c("linear", "no_conversion"),

--- a/tests/testthat/test-01_check_user_input.R
+++ b/tests/testthat/test-01_check_user_input.R
@@ -1,24 +1,29 @@
 test_that("gdp argument", {
   gdp <- tibble::tibble("iso3c" = "EUR", "year" = 2010, "value2" = 100)
-  expect_error(check_user_input(gdp), "Invalid 'gdp' argument. 'gdp' does not have the required 'value' column.")
+  expect_error(check_user_input(gdp, unit_in = "current LCU", unit_out = "constant 2017 Int$PPP"),
+               "Invalid 'gdp' argument. 'gdp' does not have the required 'value' column.")
 
   gdp <- tibble::tibble("iso3c" = "EUR", "year" = 2007, "value" = "100")
-  expect_error(check_user_input(gdp), "Invalid 'gdp' argument. The 'value' column is not numeric.")
+  expect_error(check_user_input(gdp, unit_in = "current LCU", unit_out = "constant 2017 Int$PPP"),
+               "Invalid 'gdp' argument. The 'value' column is not numeric.")
 
   gdp <- "blabla"
-  expect_error(check_user_input(gdp), "Invalid 'gdp' argument. 'gdp' is neither a data-frame nor a 'magpie' object.")
+  expect_error(check_user_input(gdp, unit_in = "current LCU", unit_out = "constant 2017 Int$PPP"),
+               "Invalid 'gdp' argument. 'gdp' is neither a data-frame nor a 'magpie' object.")
   gdp <- array()
-  expect_error(check_user_input(gdp), "Invalid 'gdp' argument. 'gdp' is neither a data-frame nor a 'magpie' object.")
+  expect_error(check_user_input(gdp, unit_in = "current LCU", unit_out = "constant 2017 Int$PPP"),
+               "Invalid 'gdp' argument. 'gdp' is neither a data-frame nor a 'magpie' object.")
 
   if (rlang::is_installed("magclass")) {
     gdp <- magclass::new.magpie()
-    expect_error(check_user_input(gdp), "Invalid 'gdp' argument. No year information in magpie object.")
+    expect_error(check_user_input(gdp, unit_in = "current LCU", unit_out = "constant 2017 Int$PPP"),
+                 "Invalid 'gdp' argument. No year information in magpie object.")
   }
 })
 
 test_that("unit arguments", {
   gdp <- tibble::tibble("iso3c" = "EUR", "year" = 2010, "value" = 100)
-  expect_error(check_user_input(gdp, unit_in = "blabla"), "Invalid 'unit_in' argument")
+  expect_error(check_user_input(gdp, unit_in = "blabla", unit_out = "blabla"), "Invalid 'unit_in' argument")
   expect_error(check_user_input(gdp, unit_in = "current LCU", unit_out = 2), "Invalid 'unit_out' argument")
 })
 

--- a/tests/testthat/test-05_convertGDP.R
+++ b/tests/testthat/test-05_convertGDP.R
@@ -72,14 +72,21 @@ test_that("convertGDP magpie object", {
                                   years = c(2001, 2002),
                                   names = c("ssp1", "ssp2"),
                                   fill = 100)
+  gdp_in3 <- magclass::new.magpie("USA",
+                                  years = NULL,
+                                  names = c("ssp1", "ssp2"),
+                                  fill = 100)
+
   gdp_conv  <- convertGDP(gdp_in, "current LCU", "constant 2017 Int$PPP")
   gdp_conv2 <- convertGDP(gdp_in2, "current LCU", "constant 2017 Int$PPP")
-
+  gdp_conv3 <- convertGDP(gdp_in3, "constant 2005 LCU", "constant 2017 Int$PPP")
 
   expect_s4_class(gdp_conv, "magpie")
   expect_s4_class(gdp_conv2, "magpie")
+  expect_s4_class(gdp_conv3, "magpie")
   expect_mapequal(magclass::getSets(gdp_in),  magclass::getSets(gdp_conv))
   expect_mapequal(magclass::getSets(gdp_in2), magclass::getSets(gdp_conv2))
+  expect_mapequal(magclass::getSets(gdp_in3), magclass::getSets(gdp_conv3))
 })
 
 


### PR DESCRIPTION
This extends convertGDP to handle magclass objects with NULL as years dimension (assuming the unit conversion does not require the years for conversion, aka "current"))