### PR TITLE
Allow magclass objects without years

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2027862'
+ValidationKey: '2053408'
 AutocreateReadme: no
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'GDPuc: Easily Convert GDP Data'
-version: 1.0.2
-date-released: '2024-06-07'
+version: 1.0.3
+date-released: '2024-08-01'
 abstract: Convert GDP time series data from one unit to another. All common GDP units
   are included, i.e. current and constant local currency units, US$ via market exchange
   rates and international dollars via purchasing power parities.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,4 +42,4 @@ VignetteBuilder:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GDPuc
 Title: Easily Convert GDP Data
-Version: 1.0.2
-Date: 2024-06-07
+Version: 1.0.3
+Date: 2024-08-01
 Authors@R:
     person("Johannes", "Koch", , "jokoch@pik-potsdam.de", role = c("aut", "cre"))
 Description: Convert GDP time series data from one unit to

--- a/R/check_user_input.R
+++ b/R/check_user_input.R
@@ -38,12 +38,6 @@ check_gdp <- function(gdp) {
   } else if (inherits(gdp, "magpie")) {
     # Check for magclass package
     rlang::check_installed("magclass", reason = "in order for magpie objects to be recognized.")
-    # Check if there is years info
-    if (is.null(magclass::getYears(gdp))) {
-      # I need at least one explizit call to a crayon:: function... otherwise I get a CRAN note
-      h <- crayon::bold("magpie")
-      abort("Invalid 'gdp' argument. No year information in {h} object.")
-    }
   } else {
     abort("Invalid 'gdp' argument. 'gdp' is neither a data-frame nor a 'magpie' object.")
   }

--- a/R/convertGDP.R
+++ b/R/convertGDP.R
@@ -76,7 +76,7 @@
 #'     \item "regional_average": missing conversion factors in the source object are replaced with
 #'     the regional average of the region to which the country belongs. This requires a region-mapping to
 #'     be passed to the function, see the with_regions argument.
-#'     \item "with USA": missing conversion factors in the source object are replaced with
+#'     \item "with_USA": missing conversion factors in the source object are replaced with
 #'     the conversion factors of the USA.
 #'   }
 #'   Can also be a vector with "linear" as first element, e.g. c("linear", 0) or c("linear", "no_conversion"),
@@ -142,10 +142,9 @@ convertGDP <- function(gdp,
     {if ("base_x" %in% names(internal)) c(., "base_x" = internal$base_x) else .} %>%
     {if ("base_y" %in% names(internal)) c(., "base_y" = internal$base_y) else .}
 
-
-  cli_inform(function() cli::cli_alert_info(
-    "Converting GDP with conversion factors from {crayon::blue(internal$source_name)}:")
-  )
+  # At least one explicit call to a crayon:: function is required to avoid CRAN note.
+  h <- crayon::blue(internal$source_name)
+  cli_inform(function() cli::cli_alert_info("Converting GDP with conversion factors from {h}:"))
 
   # Call function
   x <- do.call(f, a)

--- a/R/transform_user_input.R
+++ b/R/transform_user_input.R
@@ -5,13 +5,14 @@ transform_user_input <- function(gdp, unit_in, unit_out, source, use_USA_deflato
   # Convert to tibble, if necessary
   if (class(gdp)[1] == "magpie") {
     # Check if the magpie object has 2 spatial dimensions
-    spat2 <- all(grepl("\\.", magclass::getItems(gdp, dim = 1)))
-    gdp <- tibble::as_tibble(gdp)
-    if (!spat2) {
-      gdp <- gdp %>% dplyr::rename("iso3c" = 1, "year" = 2)
-    } else {
-      gdp <- gdp %>% dplyr::rename("iso3c" = 1, "spatial2" = 2, "year" = 3)
-    }
+    spat2 <- magclass::ndim(gdp, dim = 1) == 2
+    # Check if the magpie object has year info
+    hasYears <- !is.null(magclass::getYears(gdp))
+    # Transform to tibble and rename columns
+    gdp <- gdp %>% tibble::as_tibble() %>% dplyr::rename("iso3c" = 1)
+    if (spat2) gdp <- dplyr::rename(gdp, "spatial2" = 2)
+    if (hasYears && !spat2) gdp <- dplyr::rename(gdp, "year" = 2)
+    if (hasYears && spat2) gdp <- dplyr::rename(gdp, "year" = 3)
   }
 
   # Extract base years if they exist, and adjust string

--- a/man/convertGDP.Rd
+++ b/man/convertGDP.Rd
@@ -83,7 +83,7 @@ For the extrapolation, the closest 5 data points are used.
 \item "regional_average": missing conversion factors in the source object are replaced with
 the regional average of the region to which the country belongs. This requires a region-mapping to
 be passed to the function, see the with_regions argument.
-\item "with USA": missing conversion factors in the source object are replaced with
+\item "with_USA": missing conversion factors in the source object are replaced with
 the conversion factors of the USA.
 }
 Can also be a vector with "linear" as first element, e.g. c("linear", 0) or c("linear", "no_conversion"),

--- a/tests/testthat/test-01_check_user_input.R
+++ b/tests/testthat/test-01_check_user_input.R
@@ -9,11 +9,6 @@ test_that("gdp argument", {
   expect_error(check_user_input(gdp), "Invalid 'gdp' argument. 'gdp' is neither a data-frame nor a 'magpie' object.")
   gdp <- array()
   expect_error(check_user_input(gdp), "Invalid 'gdp' argument. 'gdp' is neither a data-frame nor a 'magpie' object.")
-
-  if (rlang::is_installed("magclass")) {
-    gdp <- magclass::new.magpie()
-    expect_error(check_user_input(gdp), "Invalid 'gdp' argument. No year information in magpie object.")
-  }
 })
 
 test_that("unit arguments", {

--- a/tests/testthat/test-02_transform_user_input.R
+++ b/tests/testthat/test-02_transform_user_input.R
@@ -5,13 +5,39 @@ test_that("source and unit year compatibility", {
                                     unit_in = "constant 2010 LCU",
                                     unit_out = "constant 2100 LCU",
                                     source = "wb_wdi",
+                                    use_USA_deflator_for_all = FALSE,
                                     with_regions = NULL,
                                     replace_NAs = NULL))
   expect_error(transform_user_input(gdp,
                                     unit_in = "constant 2100 LCU",
                                     unit_out = "constant 2010 LCU",
                                     source = "wb_wdi",
+                                    use_USA_deflator_for_all = FALSE,
                                     with_regions = NULL,
                                     replace_NAs = NULL))
 
+})
+
+test_that("unit and year availability compatibility", {
+  gdp <- tibble::tibble("iso3c" = "DEU", "value" = 100)
+  gdp2 <- magclass::new.magpie("USA", years = NULL, names = c("ssp1", "ssp2"), fill = 100)
+
+  expect_error(transform_user_input(gdp,
+                                    unit_in = "current LCU",
+                                    unit_out = "constant 2010 LCU",
+                                    source = "wb_wdi",
+                                    use_USA_deflator_for_all = FALSE,
+                                    with_regions = NULL,
+                                    replace_NAs = NULL),
+               glue::glue("Invalid 'gdp' argument. 'gdp' does not have a 'year' column, required when \\
+                          converting current values, and no other column could be identified in its stead."))
+  expect_error(transform_user_input(gdp2,
+                                    unit_in = "current LCU",
+                                    unit_out = "constant 2010 LCU",
+                                    source = "wb_wdi",
+                                    use_USA_deflator_for_all = FALSE,
+                                    with_regions = NULL,
+                                    replace_NAs = NULL),
+               glue::glue("Invalid 'gdp' argument. 'gdp' does not have a 'year' column, required when \\
+                          converting current values, and no other column could be identified in its stead."))
 })

--- a/tests/testthat/test-05_convertGDP.R
+++ b/tests/testthat/test-05_convertGDP.R
@@ -72,14 +72,20 @@ test_that("convertGDP magpie object", {
                                   years = c(2001, 2002),
                                   names = c("ssp1", "ssp2"),
                                   fill = 100)
+  gdp_in3 <- magclass::new.magpie("USA",
+                                  years = NULL,
+                                  names = c("ssp1", "ssp2"),
+                                  fill = 100)
   gdp_conv  <- convertGDP(gdp_in, "current LCU", "constant 2017 Int$PPP")
   gdp_conv2 <- convertGDP(gdp_in2, "current LCU", "constant 2017 Int$PPP")
-
+  gdp_conv3 <- convertGDP(gdp_in3, "constant 2005 LCU", "constant 2017 Int$PPP")
 
   expect_s4_class(gdp_conv, "magpie")
   expect_s4_class(gdp_conv2, "magpie")
+  expect_s4_class(gdp_conv3, "magpie")
   expect_mapequal(magclass::getSets(gdp_in),  magclass::getSets(gdp_conv))
   expect_mapequal(magclass::getSets(gdp_in2), magclass::getSets(gdp_conv2))
+  expect_mapequal(magclass::getSets(gdp_in3), magclass::getSets(gdp_conv3))
 })
 
 


### PR DESCRIPTION
This PR builds off of #28, thanks @fbenke-pik !! (In some places the code changes are identical.)
It does the same thing, in a slightly different manner, that I think is more in-line with previous code.

Falk's text, repeated here for clarity:
This extends convertGDP to handle magclass objects with NULL as years dimension (assuming the unit conversion does not require the years for conversion, aka "current"))