### PR TITLE
Bug fix

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2198460'
+ValidationKey: '2400720'
 AutocreateReadme: no
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'GDPuc: Easily Convert GDP Data'
-version: 1.1.0
-date-released: '2024-09-20'
+version: 1.2.0
+date-released: '2024-10-10'
 abstract: Convert GDP time series data from one unit to another. All common GDP units
   are included, i.e. current and constant local currency units, US$ via market exchange
   rates and international dollars via purchasing power parities.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GDPuc
 Title: Easily Convert GDP Data
-Version: 1.1.0
-Date: 2024-09-20
+Version: 1.2.0
+Date: 2024-10-10
 Authors@R:
     person("Johannes", "Koch", , "jokoch@pik-potsdam.de", role = c("aut", "cre"))
 Description: Convert GDP time series data from one unit to

--- a/R/check_user_input.R
+++ b/R/check_user_input.R
@@ -6,7 +6,7 @@ check_user_input <- function(gdp,
                              unit_in,
                              unit_out,
                              source,
-                             use_USA_deflator_for_all,
+                             use_USA_cf_for_all,
                              with_regions,
                              replace_NAs,
                              verbose,
@@ -15,7 +15,7 @@ check_user_input <- function(gdp,
   check_gdp(gdp)
   check_unit_in_out(unit_in, unit_out)
   source <- check_source(source)
-  check_use_USA_deflator_for_all(use_USA_deflator_for_all, unit_in, unit_out)
+  check_use_USA_cf_for_all(use_USA_cf_for_all, unit_in, unit_out)
   check_with_regions(unit_in, unit_out, source, with_regions)
   check_replace_NAs(with_regions, replace_NAs)
   check_verbose(verbose)
@@ -97,12 +97,9 @@ check_source <- function(source) {
 }
 
 # Check input parameter 'verbose'
-check_use_USA_deflator_for_all <- function(use_USA_deflator_for_all, unit_in, unit_out) {
-  if (!is.logical(use_USA_deflator_for_all)) {
-    abort("Invalid 'use_USA_deflator_for_all' argument. Has to be either TRUE or FALSE.")
-  }
-  if (use_USA_deflator_for_all && any(grepl("current", c(unit_in, unit_out)))) {
-    abort("Setting 'use_USA_deflator_for_all' to TRUE should only be applied between conversion of constant units.")
+check_use_USA_cf_for_all <- function(use_USA_cf_for_all, unit_in, unit_out) {
+  if (!is.logical(use_USA_cf_for_all)) {
+    abort("Invalid 'use_USA_cf_for_all' argument. Has to be either TRUE or FALSE.")
   }
 }
 

--- a/R/convertGDP.R
+++ b/R/convertGDP.R
@@ -57,9 +57,8 @@
 #'   a data-frame that exists in the calling environment.
 #'   Use [print_source_info()](https://pik-piam.github.io/GDPuc/reference/print_source_info.html)
 #'   to learn about the available sources.
-#' @param use_USA_deflator_for_all TRUE or FALSE (default). If TRUE, then only the USA deflator is used to adjust for
-#'   inflation, regardless of the country codes provided. This is a very specific deviation from the correct conversion
-#'   process, which nevertheless is often used in the integrated assessment community. Use carefully!
+#' @param use_USA_cf_for_all TRUE or FALSE (default). If TRUE, then the USA conversion factors are used for all
+#'   countries.
 #' @param with_regions NULL or a data-frame. The data-frame should be "country to region
 #'   mapping": one column named "iso3c" with iso3c country codes, and one column named
 #'   "region" with region codes to which the countries belong. Any regions in the gdp
@@ -76,8 +75,8 @@
 #'     \item "regional_average": missing conversion factors in the source object are replaced with
 #'     the regional average of the region to which the country belongs. This requires a region-mapping to
 #'     be passed to the function, see the with_regions argument.
-#'     \item "with_USA": missing conversion factors in the source object are replaced with
-#'     the conversion factors of the USA.
+#'     \item "with_USA": missing conversion factors in the source object are extended using US growth rates, or
+#'     if missing entirely, replaced with the conversion factors of the USA.
 #'   }
 #'   Can also be a vector with "linear" as first element, e.g. c("linear", 0) or c("linear", "no_conversion"),
 #'   in which case, the operations are done in sequence.
@@ -104,7 +103,7 @@ convertGDP <- function(gdp,
                        unit_in,
                        unit_out,
                        source = "wb_wdi",
-                       use_USA_deflator_for_all = FALSE,
+                       use_USA_cf_for_all = FALSE,
                        with_regions = NULL,
                        replace_NAs = NULL,
                        verbose = getOption("GDPuc.verbose", default = FALSE),
@@ -125,7 +124,7 @@ convertGDP <- function(gdp,
   }
 
   # Transform user input for internal use, while performing some last consistency checks
-  internal <- transform_user_input(gdp, unit_in, unit_out, source, use_USA_deflator_for_all, with_regions, replace_NAs)
+  internal <- transform_user_input(gdp, unit_in, unit_out, source, use_USA_cf_for_all, with_regions, replace_NAs)
 
   # Avoid NOTE in package check for CRAN
   . <- NULL

--- a/R/transform_user_input.R
+++ b/R/transform_user_input.R
@@ -1,5 +1,5 @@
 # Transform user input for package internal use
-transform_user_input <- function(gdp, unit_in, unit_out, source, use_USA_deflator_for_all, with_regions, replace_NAs) {
+transform_user_input <- function(gdp, unit_in, unit_out, source, use_USA_cf_for_all, with_regions, replace_NAs) {
   . <- NULL
 
   # Convert to tibble, if necessary
@@ -75,13 +75,11 @@ transform_user_input <- function(gdp, unit_in, unit_out, source, use_USA_deflato
     abort("Incompatible 'gdp' and 'source'. No information in source {crayon::bold(source_name)} for years in 'gdp'.")
   }
 
-  # Use different source if required by the replace_NAs argument
-  if (use_USA_deflator_for_all ||
+  # Use different source if required by the use_USA_cf_for_all and replace_NAs argument
+  if (use_USA_cf_for_all) source <- adapt_source_USA(gdp, source)
+  if (!use_USA_cf_for_all &&
       (!is.null(replace_NAs) && !any(sapply(c(NA, 0, "no_conversion"), setequal, replace_NAs))) ) {
-    if (use_USA_deflator_for_all || replace_NAs[1] == "with_USA") source <- adapt_source_USA(gdp, source, replace_NAs)
-    if (!is.null(replace_NAs) && !any(sapply(c(NA, 0, "no_conversion", "with_USA"), setequal, replace_NAs))){
-      source <- adapt_source(gdp, source, with_regions, replace_NAs, require_year_column)
-    }
+    source <- adapt_source(gdp, source, with_regions, replace_NAs, require_year_column)
     source_name <- paste0(source_name, "_adapted")
   }
 

--- a/man/convertGDP.Rd
+++ b/man/convertGDP.Rd
@@ -11,7 +11,7 @@ convertGDP(
   unit_in,
   unit_out,
   source = "wb_wdi",
-  use_USA_deflator_for_all = FALSE,
+  use_USA_cf_for_all = FALSE,
   with_regions = NULL,
   replace_NAs = NULL,
   verbose = getOption("GDPuc.verbose", default = FALSE),
@@ -62,9 +62,8 @@ a data-frame that exists in the calling environment.
 Use \href{https://pik-piam.github.io/GDPuc/reference/print_source_info.html}{print_source_info()}
 to learn about the available sources.}
 
-\item{use_USA_deflator_for_all}{TRUE or FALSE (default). If TRUE, then only the USA deflator is used to adjust for
-inflation, regardless of the country codes provided. This is a very specific deviation from the correct conversion
-process, which nevertheless is often used in the integrated assessment community. Use carefully!}
+\item{use_USA_cf_for_all}{TRUE or FALSE (default). If TRUE, then the USA conversion factors are used for all
+countries.}
 
 \item{with_regions}{NULL or a data-frame. The data-frame should be "country to region
 mapping": one column named "iso3c" with iso3c country codes, and one column named
@@ -83,8 +82,8 @@ For the extrapolation, the closest 5 data points are used.
 \item "regional_average": missing conversion factors in the source object are replaced with
 the regional average of the region to which the country belongs. This requires a region-mapping to
 be passed to the function, see the with_regions argument.
-\item "with_USA": missing conversion factors in the source object are replaced with
-the conversion factors of the USA.
+\item "with_USA": missing conversion factors in the source object are extended using US growth rates, or
+if missing entirely, replaced with the conversion factors of the USA.
 }
 Can also be a vector with "linear" as first element, e.g. c("linear", 0) or c("linear", "no_conversion"),
 in which case, the operations are done in sequence.}

--- a/tests/testthat/test-01_check_user_input.R
+++ b/tests/testthat/test-01_check_user_input.R
@@ -50,7 +50,7 @@ test_that("with_regions argument", {
                                 unit_in,
                                 unit_out,
                                 source = s,
-                                use_USA_deflator_for_all = FALSE,
+                                use_USA_cf_for_all = FALSE,
                                 with_regions = "blabla"))
 
   with_regions <- tibble::tibble("blabla" = "FRA", "region" = "USA")
@@ -58,7 +58,7 @@ test_that("with_regions argument", {
                                 unit_in,
                                 unit_out,
                                 source = s,
-                                use_USA_deflator_for_all = FALSE,
+                                use_USA_cf_for_all = FALSE,
                                 with_regions = with_regions))
 
   with_regions <- tibble::tibble("iso3c" = "FRA", "region" = "USA")
@@ -66,7 +66,7 @@ test_that("with_regions argument", {
                                 unit_in,
                                 "current LCU",
                                 source = s,
-                                use_USA_deflator_for_all = FALSE,
+                                use_USA_cf_for_all = FALSE,
                                 with_regions = with_regions))
 
   my_bad_source <- wb_wdi %>% dplyr::select(
@@ -81,7 +81,7 @@ test_that("with_regions argument", {
                                 unit_in,
                                 unit_out,
                                 source = s,
-                                use_USA_deflator_for_all = FALSE,
+                                use_USA_cf_for_all = FALSE,
                                 with_regions = with_regions))
 })
 
@@ -96,7 +96,7 @@ test_that("replace_NAs argument", {
                                 unit_in,
                                 unit_out,
                                 source = s,
-                                use_USA_deflator_for_all = FALSE,
+                                use_USA_cf_for_all = FALSE,
                                 replace_NAs = 2,
                                 with_regions = NULL),
                glue::glue("Invalid 'replace_NAs' argument. Has to be either NULL, NA, 0, 1, no_conversion, linear, \\
@@ -105,7 +105,7 @@ test_that("replace_NAs argument", {
                                 unit_in,
                                 unit_out,
                                 source = s,
-                                use_USA_deflator_for_all = FALSE,
+                                use_USA_cf_for_all = FALSE,
                                 replace_NAs = c(0, 1),
                                 with_regions = NULL),
                glue::glue("Invalid 'replace_NAs' argument. The only accepted combinations of arguments start with \\
@@ -115,7 +115,7 @@ test_that("replace_NAs argument", {
                      unit_in,
                      unit_out,
                      source = s,
-                     use_USA_deflator_for_all = FALSE,
+                     use_USA_cf_for_all = FALSE,
                      replace_NAs = "linear_regional_average",
                      with_regions = NULL)
   )
@@ -125,7 +125,7 @@ test_that("replace_NAs argument", {
                      unit_in,
                      unit_out,
                      source = s,
-                     use_USA_deflator_for_all = FALSE,
+                     use_USA_cf_for_all = FALSE,
                      replace_NAs = "regional_average",
                      with_regions = NULL),
     glue::glue("Using 'regional_average' requires a region mapping. The 'with_regions' argument can't be NULL.")
@@ -143,7 +143,7 @@ test_that("boolean arguments", {
                                 unit_in,
                                 unit_out,
                                 source = s,
-                                use_USA_deflator_for_all = FALSE,
+                                use_USA_cf_for_all = FALSE,
                                 with_regions = NULL,
                                 replace_NAs = NULL,
                                 verbose = "blabla"))
@@ -153,7 +153,7 @@ test_that("boolean arguments", {
     unit_in,
     unit_out,
     source = s,
-    use_USA_deflator_for_all = FALSE,
+    use_USA_cf_for_all = FALSE,
     with_regions = NULL,
     replace_NAs = NULL,
     verbose = TRUE,
@@ -164,27 +164,7 @@ test_that("boolean arguments", {
     unit_in,
     unit_out,
     source = s,
-    use_USA_deflator_for_all = "blabla",
-    with_regions = NULL,
-    replace_NAs = NULL,
-    verbose = TRUE,
-    return_cfs = TRUE))
-})
-
-
-test_that("boolean arguments", {
-
-  gdp <- tibble::tibble("iso3c" = "EUR", "year" = 2010, "value" = 100)
-  unit_in <- "current Int$PPP"
-  unit_out <- "constant 2010 US$MER"
-  s <- wb_wdi
-
-  expect_error(check_user_input(
-    gdp,
-    unit_in,
-    unit_out,
-    source = s,
-    use_USA_deflator_for_all = TRUE,
+    use_USA_cf_for_all = "blabla",
     with_regions = NULL,
     replace_NAs = NULL,
     verbose = TRUE,

--- a/tests/testthat/test-02_transform_user_input.R
+++ b/tests/testthat/test-02_transform_user_input.R
@@ -5,14 +5,14 @@ test_that("source and unit year compatibility", {
                                     unit_in = "constant 2010 LCU",
                                     unit_out = "constant 2100 LCU",
                                     source = "wb_wdi",
-                                    use_USA_deflator_for_all = FALSE,
+                                    use_USA_cf_for_all = FALSE,
                                     with_regions = NULL,
                                     replace_NAs = NULL))
   expect_error(transform_user_input(gdp,
                                     unit_in = "constant 2100 LCU",
                                     unit_out = "constant 2010 LCU",
                                     source = "wb_wdi",
-                                    use_USA_deflator_for_all = FALSE,
+                                    use_USA_cf_for_all = FALSE,
                                     with_regions = NULL,
                                     replace_NAs = NULL))
 
@@ -26,7 +26,7 @@ test_that("unit and year availability compatibility", {
                                     unit_in = "current LCU",
                                     unit_out = "constant 2010 LCU",
                                     source = "wb_wdi",
-                                    use_USA_deflator_for_all = FALSE,
+                                    use_USA_cf_for_all = FALSE,
                                     with_regions = NULL,
                                     replace_NAs = NULL),
                glue::glue("Invalid 'gdp' argument. 'gdp' does not have a 'year' column, required when \\
@@ -35,7 +35,7 @@ test_that("unit and year availability compatibility", {
                                     unit_in = "current LCU",
                                     unit_out = "constant 2010 LCU",
                                     source = "wb_wdi",
-                                    use_USA_deflator_for_all = FALSE,
+                                    use_USA_cf_for_all = FALSE,
                                     with_regions = NULL,
                                     replace_NAs = NULL),
                glue::glue("Invalid 'gdp' argument. 'gdp' does not have a 'year' column, required when \\

--- a/tests/testthat/test-05_convertGDP.R
+++ b/tests/testthat/test-05_convertGDP.R
@@ -172,7 +172,7 @@ test_that("convertGDP using US conversion factors", {
   gdp2_conv <- convertGDP(gdp_2,
                           unit_in = "constant 2015 LCU",
                           unit_out = "constant 2017 LCU",
-                          use_USA_deflator_for_all = TRUE)
+                          use_USA_cf_for_all = TRUE)
   gdp3_conv <- convertGDP(gdp_3,
                           unit_in = "constant 2015 LCU",
                           unit_out = "constant 2017 LCU",


### PR DESCRIPTION
Setting `replace_NAs = "with_USA"` now does the following:
- for countries with partially missing conversion factor data: inter-and extrapolates using the growth rates of the USA, 
- for countries with no conversion factor data: uses the conversion factors of the USA

It can also be used in combination with "linear": `replace_NAs = c("linear", "with_USA"`).